### PR TITLE
:sparkles: feat: Adição de seção para Medicações Recentes não atualizadas

### DIFF
--- a/frontend/app/(tabs)/add.tsx
+++ b/frontend/app/(tabs)/add.tsx
@@ -129,7 +129,7 @@ const RegisterMedication = () => {
       quantidade: currentStock,
       observacao: additionalInfo,
       status: null,
-      duracao: parseInt(duracaoTratamento),
+      duracaoTratamento: parseInt(duracaoTratamento),
     };
 
     // criar instância da classe ApiServices

--- a/frontend/app/(tabs)/home.tsx
+++ b/frontend/app/(tabs)/home.tsx
@@ -6,6 +6,7 @@ import { useFonts, Katibeh_400Regular } from '@expo-google-fonts/katibeh';
 import axios from 'axios';
 import AnimatedHeader from '../../components/Header';
 import { format, parseISO, isPast, isFuture } from 'date-fns';
+import RecentMedications from '@/entities/RecentMedications';
 
 interface Medication {
   id: number;
@@ -110,6 +111,10 @@ const Home = () => {
               <MedicationSchedule />
             </View>
           </View>
+
+          {/* Seção para Medicações Recentes (Medicações que não foi atualizado pelo usuário
+          a informação de que tomou a medicação) */}
+          <RecentMedications />
         </View>
       </Animated.ScrollView>
     </SafeAreaView>

--- a/frontend/entities/RecentMedications.tsx
+++ b/frontend/entities/RecentMedications.tsx
@@ -1,0 +1,141 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TouchableOpacity, ActivityIndicator, useWindowDimensions } from 'react-native';
+import { MedicamentoEntity } from '../entities/medicamentoEntity';
+import { mockApiService } from '../services/mockApiService';
+
+interface MedicationCardProps {
+  medicamento: MedicamentoEntity;
+  onUpdateStatus: (id: number, status: string) => Promise<void>;
+}
+
+const MedicationCard: React.FC<MedicationCardProps> = ({ medicamento, onUpdateStatus }) => {
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const handleStatusUpdate = async (status: string) => {
+    setIsUpdating(true);
+    try {
+      await onUpdateStatus(medicamento.id, status);
+    } catch (error) {
+      console.error('Erro ao atualizar status:', error);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return (
+    <View style={{ backgroundColor: '#f9fafb', borderRadius: 12, padding: 16, marginBottom: 12 }}>
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+        {/* Informações da medicação */}
+        <View style={{ flex: 1, marginRight: 16 }}>
+          <Text style={{ fontSize: 18, fontWeight: '600', color: '#36555E' }}>{medicamento.nome}</Text>
+          <Text style={{ fontSize: 14, color: '#4b5563' }}>
+            Dose: {medicamento.dosagem} - {medicamento.quantidade}
+          </Text>
+          <Text style={{ fontSize: 14, color: '#4b5563' }}>
+            Horário: {new Date(medicamento.dataInicial).toLocaleDateString()} às {medicamento.horaInicial}
+          </Text>
+        </View>
+
+        {/* Botões */}
+        {isUpdating ? (
+          <ActivityIndicator color="#36555E" />
+        ) : (
+          <View style={{ flexDirection: 'row', gap: 8 }}>
+            <TouchableOpacity
+              style={{ backgroundColor: '#22c55e', paddingHorizontal: 12, paddingVertical: 8, borderRadius: 8 }}
+              onPress={() => handleStatusUpdate('TOMADO')}
+            >
+              <Text style={{ color: 'white', textAlign: 'center', fontSize: 14 }}>Tomei</Text>
+            </TouchableOpacity>
+            
+            <TouchableOpacity
+              style={{ backgroundColor: '#ef4444', paddingHorizontal: 12, paddingVertical: 8, borderRadius: 8 }}
+              onPress={() => handleStatusUpdate('NAO_TOMADO')}
+            >
+              <Text style={{ color: 'white', textAlign: 'center', fontSize: 14 }}>Não Tomei</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </View>
+    </View>
+  );
+};
+
+const RecentMedications: React.FC = () => {
+  const [medications, setMedications] = useState<MedicamentoEntity[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { width } = useWindowDimensions();
+  const cardWidth = Math.min(width - 32, 768);
+    
+
+  const fetchRecentMedications = async () => {
+    setLoading(true);
+    try {
+      const response = await mockApiService.getMedicacoesRecentes();
+      setMedications(response);
+      setError(null);
+    } catch (err) {
+      setError('Erro ao carregar medicações');
+      console.error('Erro ao buscar medicações:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateMedicationStatus = async (id: number, status: string) => {
+    try {
+      await mockApiService.updateStatusMedicacao(id, status);
+      await fetchRecentMedications();
+    } catch (error) {
+      console.error('Erro ao atualizar status da medicação:', error);
+    }
+  };
+
+  useEffect(() => {
+    fetchRecentMedications();
+  }, []);
+
+  if (loading) {
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 16 }}>
+        <ActivityIndicator size="large" color="#36555E" testID="loading-indicator" />
+      </View>
+    );
+  }
+
+  return (
+    <View className="mb-6 w-full" style={{ maxWidth: cardWidth }}>
+      <View className="bg-white rounded-2xl p-4 sm:p-6 relative shadow-md">
+        <Text 
+          className="text-[#36555E] text-4xl sm:text-5xl font-light" 
+          style={{ fontFamily: 'Katibeh_400Regular' }}
+        >
+          Medicações Recentes
+        </Text>
+        
+        <View style={{ marginTop: 16 }}>
+          {error ? (
+            <Text style={{ color: '#ef4444', textAlign: 'center', fontSize: 18, marginTop: 16 }}>
+              {error}
+            </Text>
+          ) : medications.length === 0 ? (
+            <Text style={{ color: '#2D3648', fontSize: 18, marginTop: 16 }}>
+              Nenhuma medicação pendente
+            </Text>
+          ) : (
+            medications.map((med) => (
+              <MedicationCard
+                key={med.id}
+                medicamento={med}
+                onUpdateStatus={updateMedicationStatus}
+              />
+            ))
+          )}
+        </View>
+      </View>
+    </View>
+  );
+};
+
+export default RecentMedications;

--- a/frontend/services/apiServices.ts
+++ b/frontend/services/apiServices.ts
@@ -53,4 +53,24 @@ export class ApiServices {
             Alert.alert('Não foi possível adicionar estoque ao medicamento. Tente novamente.');
         }
     }
+
+    // função para buscar medicações recentes sem status atualizado
+    async getMedicacoesRecentes(usuarioId: number) {
+        try {
+            // IMPLEMENTAR
+        } catch (error) {
+            console.error('Erro ao buscar medicações recentes:', error);
+        }
+        return [];
+    }
+
+    // função para atualizar status da medicação
+    async updateStatusMedicacao(medicacaoId: number, status: string) {
+        try {
+            // IMPLEMENTAR
+        } catch (error) {
+            console.error('Erro ao atualizar status da medicação:', error);
+        }
+    }
+
 }

--- a/frontend/services/mockApiService.ts
+++ b/frontend/services/mockApiService.ts
@@ -1,0 +1,47 @@
+// mockApiService.ts
+import { MedicamentoEntity } from '../entities/medicamentoEntity';
+
+// Dados mockados para teste
+const mockMedications = [
+  {
+    id: 1,
+    nome: "Paracetamol",
+    laboratorio: "Medley",
+    dataInicial: new Date('2025-01-14T10:00:00'),
+    horaInicial: "10:00",
+    frequencia: "8 em 8 horas",
+    dosagem: "750mg",
+    quantidade: "1 comprimido",
+    observacao: "Tomar após as refeições",
+    status: null,
+    duracaoTratamento: 7
+  },
+  {
+    id: 2,
+    nome: "Ibuprofeno",
+    laboratorio: "EMS",
+    dataInicial: new Date('2025-01-14T14:00:00'),
+    horaInicial: "14:00",
+    frequencia: "12 em 12 horas",
+    dosagem: "600mg",
+    quantidade: "1 comprimido",
+    observacao: "Tomar com água",
+    status: null,
+    duracaoTratamento: 5
+  }
+];
+
+// Mock das funções da API
+export const mockApiService = {
+  getMedicacoesRecentes: async (): Promise<MedicamentoEntity[]> => {
+    // Simula um delay de rede
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    return mockMedications;
+  },
+
+  updateStatusMedicacao: async (id: number, status: string): Promise<void> => {
+    // Simula um delay de rede
+    await new Promise(resolve => setTimeout(resolve, 500));
+    console.log(`Medicação ${id} marcada como ${status}`);
+  }
+};


### PR DESCRIPTION
- Esta PR tem como objetivo incrementar a Home Page do "Remedius" com a seção para Medicações Recentes, exibindo para o usuário aquelas medicações cujos data e horário de aplicação já foram ultrapassados, mas o usuário não atualizou seu status (informou se a medicação foi "tomada" ou "não tomada"). 
- Como ainda não foram implementados os métodos no backend que permitem retornar uma resposta coerente contendo as Medicações Recentes, nem atualizar o status de um evento das medicações, foi utilizado um "mock" (simulação) da API, a ser removido/alterado quando a implementação legítima da API for realizada.
- Closes #102 